### PR TITLE
Ignore www subdomains

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ def scrape_recipe(url):
     if not recipe:
         parsed_uri = urllib.parse.urlparse(url)
         domain = parsed_uri.netloc.lower()
+        domain = domain.replace('www.', '', 1) if domain.startswith('www.') else domain
         parser = parsers.getParser(domain)
 
         if parser is None:

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -6,12 +6,12 @@ from parsers.minimalistbaker import Minimalistbaker
 from parsers.bowlofdelicious import Bowlofdelicious
 
 PARSERS = {
-    'www.gimmesomeoven.com': Gimmesomeoven,
+    'gimmesomeoven.com': Gimmesomeoven,
     'smittenkitchen.com': Smittenkitchen,
     'letsdishrecipes.com': Letsdishrecipes,
     'lovingitvegan.com': Lovingitvegan,
     'minimalistbaker.com': Minimalistbaker,
-    'www.bowlofdelicious.com': Bowlofdelicious,
+    'bowlofdelicious.com': Bowlofdelicious,
 }
 
 def getParser(domain):


### PR DESCRIPTION
When checking our own stash of parsers, strip `www`'s from the parsed url
netloc.

Straightforward way of dealing with #4 without bringing regex's into the equation?