### PR TITLE
Fixes Issue 7: adds a seriouseats.com parser

### DIFF
--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -15,6 +15,7 @@ from parsers.thewoksoflife import Thewoksoflife
 from parsers.glebekitchen import GlebeKitchen
 from parsers.akispetretzikis import AkisPetretzikis
 from parsers.hervecuisine import Hervecuisine
+from parsers.seriouseats import Seriouseats
 
 # Must exclude the "www" portion of the URL
 PARSERS = {
@@ -33,7 +34,8 @@ PARSERS = {
     'thewoksoflife.com': Thewoksoflife,
     'glebekitchen.com': GlebeKitchen,
     'akispetretzikis.com': AkisPetretzikis,
-    'hervecuisine.com': Hervecuisine
+    'hervecuisine.com': Hervecuisine,
+    'seriouseats.com' : Seriouseats
 }
 
 def getParser(domain):

--- a/parsers/seriouseats.py
+++ b/parsers/seriouseats.py
@@ -1,42 +1,19 @@
 from parsers.recipe import Recipe
+import recipe_scrapers
+
 
 class Seriouseats(Recipe):
-
-    def scrape_recipe(self, soup):
-        recipe = {}
-
-        name = soup.find('h1', {'class': 'title'})
-        recipe['name'] = name.contents[0]
-
-        result = soup.find('div', {'class': 'recipe-introduction-body'})
-        recipe['description'] = result.contents[3].text
-
-        try:  # try-except: https://www.seriouseats.com/recipes/2018/10/yeasted-pumpkin-bread.html breaks this due to it using a video, not <img>
-            result = soup.find('div', {'class': 'se-pinit-image-container'})
-            recipe['image'] = result.contents[1]['src']
-        except AttributeError:
-            recipe['image'] = None
-
-        recipe['ingredients'] = []
-        ingredients = soup.find_all('li', {'class': 'ingredient'})
-        for ingredient in ingredients:
-            recipe['ingredients'].append(ingredient.text)
-
-        recipe['instructions'] = []
-        divs = soup.find_all('div', {'class': 'recipe-procedure-text'})
-        for div in divs:
-            recipe['instructions'].append(div.text)
-
-        return recipe
-
-
     def Parse(self, url):
         recipe = {}
-        recipe['url'] = url
-        recipe['source'] = 'seriouseats.com'
 
-        soup = self.fetch_soup(url)
-        parsed_recipe = self.scrape_recipe(soup)
-        recipe.update(parsed_recipe)
+        # Scrape the provided website using the url passed in
+        scraper = recipe_scrapers.scrape_me(url)
+
+        # Assign the recipe's dictionary's keys and values using recipe_scraper dependency
+        recipe['url'] = url
+        recipe['name'] = scraper.title()
+        recipe['image'] = scraper.image()
+        recipe['ingredients'] = scraper.ingredients()
+        recipe['instructions'] = (i[3:] for i in scraper.instructions().split("\n"))  # Each ingredient starts with a number, period, and whitespace. Remove them.
 
         return recipe

--- a/parsers/seriouseats.py
+++ b/parsers/seriouseats.py
@@ -11,18 +11,21 @@ class Seriouseats(Recipe):
         result = soup.find('div', {'class': 'recipe-introduction-body'})
         recipe['description'] = result.contents[3].text
 
-        result = soup.find('div', {'class': 'se-pinit-image-container'})
-        recipe['image'] = result.contents[1]['src']
+        try:  # try-except: https://www.seriouseats.com/recipes/2018/10/yeasted-pumpkin-bread.html breaks this due to it using a video, not <img>
+            result = soup.find('div', {'class': 'se-pinit-image-container'})
+            recipe['image'] = result.contents[1]['src']
+        except AttributeError:
+            recipe['image'] = None
 
         recipe['ingredients'] = []
         ingredients = soup.find_all('li', {'class': 'ingredient'})
         for ingredient in ingredients:
-            recipe['ingredients'].append(ingredient.contents[0])
+            recipe['ingredients'].append(ingredient.text)
 
         recipe['instructions'] = []
-        instructions = soup.find_all('div', {'class': 'recipe-procedure-text'})
-        for instruction in instructions:
-            recipe['instructions'].append(instruction.contents[2].text)
+        divs = soup.find_all('div', {'class': 'recipe-procedure-text'})
+        for div in divs:
+            recipe['instructions'].append(div.text)
 
         return recipe
 

--- a/parsers/seriouseats.py
+++ b/parsers/seriouseats.py
@@ -1,0 +1,39 @@
+from parsers.recipe import Recipe
+
+class Seriouseats(Recipe):
+
+    def scrape_recipe(self, soup):
+        recipe = {}
+
+        name = soup.find('h1', {'class': 'title'})
+        recipe['name'] = name.contents[0]
+
+        result = soup.find('div', {'class': 'recipe-introduction-body'})
+        recipe['description'] = result.contents[3].text
+
+        result = soup.find('div', {'class': 'se-pinit-image-container'})
+        recipe['image'] = result.contents[1]['src']
+
+        recipe['ingredients'] = []
+        ingredients = soup.find_all('li', {'class': 'ingredient'})
+        for ingredient in ingredients:
+            recipe['ingredients'].append(ingredient.contents[0])
+
+        recipe['instructions'] = []
+        instructions = soup.find_all('div', {'class': 'recipe-procedure-text'})
+        for instruction in instructions:
+            recipe['instructions'].append(instruction.contents[2].text)
+
+        return recipe
+
+
+    def Parse(self, url):
+        recipe = {}
+        recipe['url'] = url
+        recipe['source'] = 'seriouseats.com'
+
+        soup = self.fetch_soup(url)
+        parsed_recipe = self.scrape_recipe(soup)
+        recipe.update(parsed_recipe)
+
+        return recipe


### PR DESCRIPTION
Hey there,

Please pardon the random PR. I noticed that issue #7 is still open since June and wanted to take a crack at it. 

I tried to replicate the issue using only the `recipe_scrapers` library and found that it didn't duplicate the numbers so figured it was on this end. I developed a parser specifically for `seriouseats.com` that hopefully solves the issue. I tested it with about ten recipes and found that they all scraped and displayed as expected. I also added a description field too!

I'm just a novice and not the best Python programmer, so please let me know what you think. 
-Chris

PS My avid cook of a girlfriend loves your website.