### PR TITLE
Set `supported_only=False` for recipe-scrapers

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ def scrape_recipe(url):
                 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36'
             }
             resp = requests.get(url, headers=headers).text
-            scraper = scrape_html(resp, org_url=url)
+            scraper = scrape_html(resp, org_url=url, supported_only=False)
             instructions = [i.strip() for i in scraper.instructions().split("\n") if i.strip()]
             recipe = {
                 'name': scraper.title(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4>=4.12.3
 Flask==3.0.3
 gunicorn==22.0.0
-recipe-scrapers==15.8.0
+recipe-scrapers==15.11.0


### PR DESCRIPTION
Previously called `wild_mode`, this will attempt to pull the recipe schema from sites that aren't explicitly hardcoded, works for lots of site.

As an example, [this recipe](https://www.ahealthysliceoflife.com/red-lentil-carrot-curry-recipe/) previously failed, but succeeds (with minor errors on the ingredients) with `supported_only=False` (though I'm adding that site explicitly [here](https://github.com/hhursev/recipe-scrapers/pull/1413)). I think that's an improvement over nothing, but would be willing to add some messaging to indicate "this site is only kinda supported" if you'd prefer